### PR TITLE
Suggestions about naming

### DIFF
--- a/content/presentation/index.md
+++ b/content/presentation/index.md
@@ -32,13 +32,13 @@ sections:
 
         Test on our hardware & improve kokkos for it
         * Intel PVC backend improvement
-        * NVidia Grace Hopper memory management handling
+        * Nvidia Grace Hopper memory management handling
 
         Work on specific projects in the Kokkos ecosystem
-        * [DDC](https://ddc.mdls.fr/): Discrete data & computation
-        * [Kokkos-FFT](https://kokkosfft.readthedocs.io/en/latest/): Performance portable FFT with a Kokkos API
+        * [DDC](https://ddc.mdls.fr/): Discrete Domain Computation library
+        * [Kokkos-fft](https://kokkosfft.readthedocs.io/en/latest/): Performance portable FFT with a Kokkos API
           - lead by CExA
-        * [Kokkos-comm](https://github.com/kokkos/kokkos-comm): Kokkos-MPI integration
+        * [Kokkos Comm](https://github.com/kokkos/kokkos-comm): Kokkos-MPI integration
           - co-lead by CExA
 
         Improvements to software quality


### PR DESCRIPTION
- about `NVidia`: not sure about this change but I usually see `NVIDIA` or `Nvidia`
- about `DDC`: maybe the intent was to describe DDC but I feel the words used in the description could lead to a confusion with the meaning of DDC
- about `Kokkos-FFT`, I think our official documentation only mentions either `Kokkos-fft` or `KokkosFFT`
- about `Kokkos-Comm`, same, I think the official documentation only mentions either `KokkosComm` or `Kokkos Comm`